### PR TITLE
Add safe __del__ method to BGZipWriter

### DIFF
--- a/bgzip/__init__.py
+++ b/bgzip/__init__.py
@@ -139,6 +139,13 @@ class BGZipWriter(io.IOBase):
         self.fileobj.write(bgzip_eof)
         self.fileobj.flush()
 
+    def __del__(self):
+        try:
+            if not self.closed:
+                self.close()
+        except:
+            pass
+
 class Deflater:
     def __init__(self, num_threads: int=cpu_count(), num_deflate_buffers: int=bgu.block_batch_size):
         self._num_threads = num_threads


### PR DESCRIPTION
Fixes https://github.com/DataBiosphere/bgzip/issues/87

In Python 3.13, apparently the timing at which `__del__` methods can run has changed, which for BGZip means that this inherited method (which closes the file) can run after the file has already been closed, resulting in an error:

```
Exception ignored in: <bgzip.BGZipWriter object at 0x104dd3e20>
Traceback (most recent call last):
  File "/Users/jd42/Projects/test/.venv/lib/python3.13/site-packages/bgzip/__init__.py", line 139, in close
    self.fileobj.write(bgzip_eof)
ValueError: write to closed file
```

This PR adds overrides the inherited `__del__` method to add a specific check if the file is already closed, providing compatibility with Python >=3.13.